### PR TITLE
feat: parameterize kubeconfig user for kubeadm init control plane

### DIFF
--- a/roles/kubeadm-init-controlplane/README.md
+++ b/roles/kubeadm-init-controlplane/README.md
@@ -1,0 +1,20 @@
+# kubeadm-init-controlplane role
+
+This role initializes a Kubernetes control plane node and prepares kubeconfig files for interactive use.
+
+## Configurable variables
+
+- `kubeconfig_user` (default: `ansible_user_id`): User account that owns the downloaded `admin.conf` kubeconfig for kubectl usage.
+- `kubeconfig_user_home` (default: `/root` for `root`, otherwise `/home/<kubeconfig_user>`): Home directory for `kubeconfig_user`.
+
+### Override example
+
+To place the kubeconfig under a different account, set `kubeconfig_user` when running the playbook:
+
+```yaml
+- hosts: masters
+  roles:
+    - role: kubeadm-init-controlplane
+      vars:
+        kubeconfig_user: devops
+```

--- a/roles/kubeadm-init-controlplane/defaults/main.yaml
+++ b/roles/kubeadm-init-controlplane/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+# Default user to own the kubeconfig for kubectl access
+kubeconfig_user: "{{ ansible_user_id }}"
+
+# Home directory for the kubeconfig user
+kubeconfig_user_home: "{{ '/root' if kubeconfig_user == 'root' else '/home/' ~ kubeconfig_user }}"

--- a/roles/kubeadm-init-controlplane/tasks/main.yaml
+++ b/roles/kubeadm-init-controlplane/tasks/main.yaml
@@ -37,15 +37,15 @@
 
 - name: "Create user .kube folder (4/10)"
   file:
-    path: "~/.kube"
+    path: "{{ kubeconfig_user_home }}/.kube"
     state: directory
-    owner: "jgavinray"
+    owner: "{{ kubeconfig_user }}"
 
 - name: "Copy admin.conf to user .kube folder (5/10)"
   copy:
     src: /etc/kubernetes/admin.conf
-    dest: "~/.kube/config"
-    owner: "jgavinray"
+    dest: "{{ kubeconfig_user_home }}/.kube/config"
+    owner: "{{ kubeconfig_user }}"
     remote_src: yes
 
 - name: "Create root user .kube folder (6/10)"


### PR DESCRIPTION
## Summary
- add configurable kubeconfig_user defaults for kubeconfig ownership and home path
- replace hard-coded kubeconfig paths with the configurable user’s home directory
- document how to override the kubeconfig user for the role

## Testing
- not run

